### PR TITLE
Feature: consistent headers

### DIFF
--- a/docs/accounts/sign_up.rst
+++ b/docs/accounts/sign_up.rst
@@ -1,5 +1,5 @@
 Creating an Account
-===================
+-------------------
 
 **Purpose:** The sign-up form creates an OSF account.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,7 +3,7 @@ OSF Features
 
 The OSF has an extensive (and growing!) list of features. These documents provide a comprehensive description of expected behavior, including edge cases. If you are looking for a basic "how-to" guide, visit https://osf.io/getting-started.
 
-**Note:** Think something is missing or out of date? `Submit a pull request <https://github.com/CenterForOpenScience/COSDev>`_ with your suggested changes!
+**Note:** Think something is missing or out of date? `Submit a pull request <https://github.com/CenterForOpenScience/OSFDocs>`_ with your suggested changes!
 
 To Do items are available :doc:`here <todo>`.
 

--- a/docs/navigation/navigation.rst
+++ b/docs/navigation/navigation.rst
@@ -3,7 +3,7 @@
 The navigation bar appears at the top of the page at all times. When scrolling down, the navigation bar stays stuck to the top of the page.
 
 Links included when logged out
-==============================
+------------------------------
 
 *  OSF Home tab:
     * OSF Home: Clicking this link takes the user to the OSF homepage.
@@ -31,7 +31,7 @@ Links included when logged out
 
 
 Links included when logged in
-=============================
+-----------------------------
 
 **Links included when logged in:**
 

--- a/docs/pages/pages_index.rst
+++ b/docs/pages/pages_index.rst
@@ -48,6 +48,7 @@ Public Content on the OSF
 .. _institutions:
 
 OSF institutions
+****************
 
 .. include:: institutions.rst
 

--- a/docs/pages/registries.rst
+++ b/docs/pages/registries.rst
@@ -4,7 +4,7 @@
 This page is accessible at https://osf.io/registries.
 
 Links included when logged out
-==============================
+------------------------------
 
 * OSF Registries
     
@@ -22,7 +22,7 @@ Links included when logged out
 * Sign In: Clicking this tab takes the user to the :ref:`OSF sign-in page <login>`. After logging in, the user is taken to the OSF Registraties landing page.
 
 Links included when logged in
-=============================
+-----------------------------
 
 When logged in, the navigation bar is the same, except that the "Sign Up" and "Sign In" links are replaced with the user drop-down menu:
 
@@ -34,7 +34,7 @@ When logged in, the navigation bar is the same, except that the "Sign Up" and "S
     *Log out: Clicking this link logs the user out of their OSF account and takes them to the OSF homepage, where a confirmation message will appear at the top of the page informing them that they have logged out succesfully: https://osf.io/goodbye/. 
 
 Searching OSF Registries
-========================
+------------------------
 
 OSF Registries is powered by SHARE. On the OSF Registries landing page, the user can search for registrations by typing a query into the search box or by clicking a registration in the "Browse Recent Registrations section."
 

--- a/docs/projects/request_access.rst
+++ b/docs/projects/request_access.rst
@@ -1,10 +1,10 @@
 Request Access
-==============
+--------------
 The request access feature gives non-contributors the opportunity to collaborate on and access both public and private projects. This feature must be enabled on the project for non-contributors to request access. Admins on the project can enable or disable request access via their :ref:`project Settings page <project-settings>`.
 
 
 Request access on private projects
-----------------------------------
+**********************************
 **Purpose**: To allow users who have the URL of a private project to request access to it.
 
 To request access on a private project, the user must navigate to the project's URL. They will be taken to a restricted page that reads::
@@ -22,14 +22,14 @@ Clicking the **Switch account** button takes the user to the :ref:`OSF login pag
 
 
 Request access on public projects
----------------------------------
+*********************************
 **Purpose**: Gives the opportunity for users to collaborate on research they find on OSF.
 
 To request access on a public project, the user must click the **ellipsis** button in the top right of the project "Overview" page. After clicking the button, a drop-down menu will unfold, from which the user can click the **Request access** button. Upon clicking the **Request Access** button, the button becomes disabled and updates to read **Access requested**, indicating to the user that their request has been submitted.
 
 
 Grant or reject access
-----------------------
+**********************
 **Purpose**: To allow admins to choose who can contribute to their project.
 
 When a user requests access to a project, the admins will receive an email notification titled "An OSF user has requested access to your project"::


### PR DESCRIPTION
This PR fixes up the headers for several doc sections so that they don't appear in the sidebar TOC.  Most of them were just demoted from h1 (`=`) to h2 (`*`) or h3 (`-`).

Also fixes a link to this git repo.